### PR TITLE
Fixed an GCC warning

### DIFF
--- a/huawei_bootloader_unlocker.c
+++ b/huawei_bootloader_unlocker.c
@@ -24,7 +24,7 @@ int main( int argc, char **argv) {
 	        base_start = atoll( base );
 	} else {
 		FILE * fp;
-		if(fp= fopen("lastcode","w")) {
+		if(fp== fopen("lastcode","w")) {
 		fscanf(fp,"%llu",&base_start);
 		fclose(fp);
 		}


### PR DESCRIPTION
The warning
unlock.c:27:8: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
                if(fp= fopen("lastcode","w")) {
                   ~~^~~~~~~~~~~~~~~~~~~~~~~
unlock.c:27:8: note: place parentheses around the assignment to silence this warning
                if(fp= fopen("lastcode","w")) {
                     ^
                   (                        )
unlock.c:27:8: note: use '==' to turn this assignment into an equality comparison
                if(fp= fopen("lastcode","w")) {
                     ^
                     ==
1 warning generated.